### PR TITLE
docs: 添加 Pilio 去水印工具到 智能抠图

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@
 |[experte](https://www.experte.com/background-remover)|🆓||
 |[boolv](https://toolkit.boolv.tech/background-remover)|🆓||
 |[booltool](https://booltool.boolv.tech/home)|🆓&💰|由 OpenAI 支持|
+|[Pilio 去水印](https://pilio.ai/zh/remove-watermark)|🆓&💰|支持 AI 图片去水印、PDF 去水印与 Gemini 水印去除；图片专页：https://pilio.ai/zh/image-watermark-remover ，Gemini 专页：https://pilio.ai/zh/gemini-watermark-remover ，开源仓库：https://github.com/GargantuaX/gemini-watermark-remover|
 ## 原型设计
 
 | 产品名称                                 | 相关信息 | 备注                                                         |


### PR DESCRIPTION
这个 PR 在 README 的 `智能抠图` 分区补充了 `Pilio 去水印` 条目。

包含链接：
- 主入口：https://pilio.ai/zh/remove-watermark
- 图片去水印：https://pilio.ai/zh/image-watermark-remover
- Gemini 去水印：https://pilio.ai/zh/gemini-watermark-remover
- 开源仓库：https://github.com/GargantuaX/gemini-watermark-remover

补充信息：
- 支持 AI 图片去水印
- 支持 PDF 去水印
- 包含专门的 Gemini 水印去除页面

如果你希望放到别的分区，或者希望描述更短，我可以继续调整。
